### PR TITLE
Introduce SSL Parameter Configuration

### DIFF
--- a/config.yml.sample
+++ b/config.yml.sample
@@ -13,6 +13,7 @@ logging_level: "INFO"
 misp_servers:
   - domain: "https://example-misp-instance.com"
     api_key: "API_KEY"
+    verify_ssl: False
 
     # PyMISP.search() arguments. For complete list of options
     # consult https://pymisp.readthedocs.io/en/latest/modules.html#pymisp.PyMISP.search

--- a/src/pdnssoccli/subcommands/correlate.py
+++ b/src/pdnssoccli/subcommands/correlate.py
@@ -146,7 +146,7 @@ def correlate(ctx,
     # Set up MISP connections
     misp_connections = []
     for misp_conf in ctx.obj['CONFIG']["misp_servers"]:
-        misp = PyMISP(misp_conf['domain'], misp_conf['api_key'], True, debug=False)
+        misp = PyMISP(misp_conf['domain'], misp_conf['api_key'], ssl=misp_conf['verify_ssl'], debug=False)
         if misp:
             misp_connections.append((misp, misp_conf['args']))
 


### PR DESCRIPTION
Implemented an SSL parameter configuration feature, allowing users to specify SSL settings in the pdnssoccli.yml configuration file. This enhancement enables the use of self-signed certificates without SSL verification failures. Users can configure the SSL parameter accordingly to accommodate various SSL certificate setups, ensuring seamless integration with different environments.