### PR TITLE
Introduce SSL Parameter Configuration

### DIFF
--- a/src/pdnssoccli/subcommands/fetch_iocs.py
+++ b/src/pdnssoccli/subcommands/fetch_iocs.py
@@ -43,7 +43,7 @@ def fetch_iocs(ctx,
     # Set up MISP connections
     misp_connections = []
     for misp_conf in ctx.obj['CONFIG']["misp_servers"]:
-        misp = PyMISP(misp_conf['domain'], misp_conf['api_key'], True, debug=False)
+        misp = PyMISP(misp_conf['domain'], misp_conf['api_key'], ssl=misp_conf['verify_ssl'], debug=False)
         if misp:
             misp_connections.append((misp, misp_conf['args'], misp_conf['periods']['tags']))
 


### PR DESCRIPTION
Implemented an SSL parameter configuration feature, allowing users to specify SSL settings in the pdnssoccli.yml configuration file. This enhancement enables the use of self-signed certificates without SSL verification failures. Users can configure the SSL parameter accordingly to accommodate various SSL certificate setups, ensuring seamless integration with different environments.